### PR TITLE
Add sqltyped version

### DIFF
--- a/databench-sqltyped/src/main/resources/schema.sql
+++ b/databench-sqltyped/src/main/resources/schema.sql
@@ -1,0 +1,9 @@
+DROP SCHEMA IF EXISTS databench CASCADE;
+CREATE SCHEMA databench AUTHORIZATION postgres;
+
+create table SQLTYPED_ACCOUNT(
+  ID int NOT NULL,
+  TRANSFERS varchar NOT NULL, 
+  BALANCE int NOT NULL, 
+  PRIMARY KEY (id)
+);

--- a/databench-sqltyped/src/main/scala/databench/sqltyped/Sqltyped.scala
+++ b/databench-sqltyped/src/main/scala/databench/sqltyped/Sqltyped.scala
@@ -1,0 +1,92 @@
+package databench.sqltyped
+
+import databench.Bank
+import java.lang.{ Integer => JInt }
+import databench.AccountStatus
+import java.sql.Connection
+import scala.annotation.tailrec
+import scala.util.Try
+import scala.util.Failure
+import scala.util.Success
+import sqltyped._
+import scala.slick.session.Database
+import databench.database.PostgreSqlDatabase
+import com.jolbox.bonecp.BoneCPConfig
+import com.jolbox.bonecp.BoneCP
+import com.jolbox.bonecp.BoneCPDataSource
+
+class SqltypedPostgreSubject extends Bank[JInt] {
+  private val dataSource = {
+    import PostgreSqlDatabase._
+    PostgreSqlDatabase.loadDriver
+    val config = new BoneCPConfig
+    config.setJdbcUrl(url)
+    config.setUsername(user)
+    config.setPassword(password)
+    new BoneCPDataSource(config)
+  }
+
+  object Tables { trait SQLTYPED_ACCOUNT }
+  object Columns { }
+
+  private val database = Database.forDataSource(dataSource)
+  implicit val config = Configuration(Tables, Columns)
+  implicit def conn = Database.threadLocalSession.conn
+
+  val newAccount    = sql("INSERT INTO sqltyped_account(id, balance, transfers) VALUES (?,?,?)")
+  val updateAccount = sql("UPDATE sqltyped_account SET balance = balance + ?, transfers=(transfers || ',' || ?) WHERE id=?")
+  val accountById   = sql("SELECT balance, transfers FROM sqltyped_account WHERE id=?")
+
+  def tearDown = dataSource.close
+
+  @tailrec private def withTransactionRetry[R](f: => R): R =
+    Try(withTransaction(f)) match {
+      case Success(result) =>
+        result
+      case Failure(exception) if (
+        exception.getMessage.startsWith("ERROR: could not serialize access")) =>
+          withTransactionRetry(f)
+    }
+
+  def setUp(numberOfAccounts: JInt): Array[JInt] = {
+    createSchema
+    insertAccounts(numberOfAccounts).map(new JInt(_)).toArray
+  }
+
+  def warmUp = {}
+
+  override def additionalVMParameters(forMultipleVMs: Boolean) = ""
+
+  def transfer(from: JInt, to: JInt, value: Int) = withTransactionRetry {
+    updateAccount(-value, (-value).toString, from)
+    updateAccount(value, value.toString, to)
+  }
+
+  def getAccountStatus(id: JInt) = withTransactionRetry {
+    accountById(id) map (_.values.tupled) map { case (balance, transfers) => 
+      new AccountStatus(balance, transfers.split(',').tail.map(Integer.parseInt(_).intValue))
+    } getOrElse sys.error("no such account " + id)
+  }
+  
+  private def insertAccounts(numberOfAccounts: Integer) = withTransaction {
+    for (i <- (0 until numberOfAccounts)) yield {
+      newAccount(i, 0, " ")
+      i
+    }
+  }
+
+  private def createSchema = withTransaction {
+    val stmt = conn.createStatement
+    stmt.executeUpdate(""" CREATE SCHEMA databench AUTHORIZATION postgres """)
+    stmt.executeUpdate("""
+      create table SQLTYPED_ACCOUNT(
+        ID int NOT NULL,
+        TRANSFERS varchar NOT NULL, 
+        BALANCE int NOT NULL, 
+        PRIMARY KEY (id)
+      )""")
+    stmt.close
+  }
+  
+  private def withTransaction[R](f: => R): R = database.withTransaction(f)
+}

--- a/project/DatabenchBuild.scala
+++ b/project/DatabenchBuild.scala
@@ -60,6 +60,27 @@ object DatabenchBuild extends Build {
 		    )
 		)
 
+	val sqltyped = "fi.reaktor" %% "sqltyped" % "0.2.1"
+
+	lazy val databenchSqltyped = 
+		Project(
+			id = "databench-sqltyped",
+			base = file("databench-sqltyped"),
+			dependencies = Seq(databenchBank),
+			settings = commonSettings ++ Seq(
+		      libraryDependencies ++= 
+		    	  Seq(sqltyped, slick, boneCP),
+                          initialize ~= { _ => initSqltyped }
+		    )
+		)
+
+        def initSqltyped {
+          System.setProperty("sqltyped.url", "jdbc:postgresql://localhost/databench")
+          System.setProperty("sqltyped.driver", "org.postgresql.Driver")
+          System.setProperty("sqltyped.username", "postgres")
+          System.setProperty("sqltyped.password", "postgres")
+        }
+
 	val prevaylerCore = "org.prevayler" % "prevayler-core" % "2.6"
 	val prevaylerFactory = "org.prevayler" % "prevayler-factory" % "2.6"
 	val prevaylerXStream = "org.prevayler.extras" % "prevayler-xstream" % "2.6"
@@ -145,7 +166,7 @@ object DatabenchBuild extends Build {
 			base = file("databench-runner"),
 			dependencies = Seq(databenchBank, databenchActivate,
 		    			databenchSlick, databenchPrevayler, databenchJpa,
-		    			databenchSqueryl, databenchDb4o, databenchEbean),
+		    			databenchSqueryl, databenchDb4o, databenchEbean, databenchSqltyped),
 			settings = commonSettings ++ assemblySettings ++ Seq(
 					libraryDependencies ++= Seq(
 						reflections, gfork, scalaTest, mysql, 


### PR DESCRIPTION
Hi,

This pull request adds an implementation with sqltyped:

https://github.com/jonifreeman/sqltyped

It would be nice to see how it fares in this kind of benchmark. Please note that for sqltyped to work it needs the schema already at compile time. Sqltyped connects to the database at compile time to read database metadata which it uses to integrate SQL statements with Scala type system. Therefore the provided schema.sql script must be run before compilation:

sudo -u postgres psql databench < databench/databench-sqltyped/src/main/resources/schema.sql

My sbt-fu was not good enough to automate that step :)

Please let me know if I misunderstood some critical requirement and therefore didn't implement the benchmark correctly.

Cheers Joni
